### PR TITLE
add stimulus_reflex as dependency to gemspec

### DIFF
--- a/stimulus_reflex_testing.gemspec
+++ b/stimulus_reflex_testing.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  
+  spec.add_dependency "stimulus_reflex"
 end


### PR DESCRIPTION
Thanks for putting all this together!  When I added the gem to my project's Gemfile, I had `stimulus_reflex_testing` before `stimulus_reflex` and it caused an uninitialized constant error.  This change should remove that gotcha.