### PR TITLE
Update for compatibility with stimulus_reflex 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this line to your application's Gemfile:
 gem 'stimulus_reflex_testing', require: false
 ```
 
-and add the following to `spec/rails_helper.rb`:
+and add the following to `test/test_helper.rb`:
 
 ```ruby
 require 'stimulus_reflex_testing'

--- a/README.md
+++ b/README.md
@@ -21,18 +21,12 @@ Add this line to your application's Gemfile:
 gem 'stimulus_reflex_testing', require: false
 ```
 
-and add the following to `test/test_helper.rb`:
-
-```ruby
-require 'stimulus_reflex_testing'
-```
-
 ### Using 5.2 or below? Or using a version of RSpec Rails lower than 4?
 
 Both Rails 6 and RSpec Rails 4 introduce the `action-cable-testing` library. If you're using Rails 5.2 and a version of RSpec Rails lower than 4, include the `action-cable-testing` gem in your Gemfile.
 
 ```ruby
-gem 'stimulus_reflex_testing'
+gem 'stimulus_reflex_testing', require: false
 gem 'action-cable-testing'
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Things we'd like to add/improve on:
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'stimulus_reflex_testing'
+gem 'stimulus_reflex_testing', require: false
+```
+
+and add the following to `spec/rails_helper.rb`:
+
+```ruby
+require 'stimulus_reflex_testing'
 ```
 
 ### Using 5.2 or below? Or using a version of RSpec Rails lower than 4?

--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -5,9 +5,19 @@ class StimulusReflex::TestCase < ActiveSupport::TestCase
   class TestChannel < ActionCable::Channel::TestCase
     _channel_class = StimulusReflex::Channel
 
+    delegate :env, to: :connection
+
     def initialize(connection_opts = {})
       super("StimulusReflex::Channel")
       @connection = stub_connection(connection_opts.merge(env: {}))
+    end
+
+    def stream_name
+      ids = connection.identifiers.map { |identifier| connection.send(identifier).try(:id) || connection.send(identifier) }
+      [
+        "StimulusReflex::Channel",
+        ids.select(&:present?).join(";")
+      ].select(&:present?).join(":")
     end
   end
 


### PR DESCRIPTION
StimulusReflex 3.4 adds a few methods that StimulusReflex::TestCase::TestChannel needs to stub.

Additionally, in SR 3.4 StimulusReflex::Channel has been moved to being autoloaded by Zeitwerk and is not available at the Bundler.require stage.  I've updated the README with revised installation instructions that require stimulus_reflex_testing in rails_helper.

This fixes #6 