### PR TITLE
Pass method_name to reflex class

### DIFF
--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -24,7 +24,7 @@ class StimulusReflex::TestCase < ActiveSupport::TestCase
       element = opts.fetch(:element, StimulusReflex::Element.new)
 
       self.class.reflex_class.new(
-        channel, element: element, url: opts.dig(:url), params: opts.fetch(:params, {})
+        channel, element: element, url: opts.dig(:url), method_name: opts.dig(:method_name), params: opts.fetch(:params, {})
       )
     end
   end


### PR DESCRIPTION
This PR makes `method_name` an optional argument on `build_reflex`, as discussed in https://github.com/podia/stimulus_reflex_testing/issues/5.

As mentioned in that issue, this implementation requires repeating yourself to set the method name twice, ie:

```rb
reflex = build_reflex(url: "foo", method_name: "create")
reflex.run(:create)
```

Definitely open to better ideas here, but this has at least unblocked me for the time being. Thanks for your help!