### PR TITLE
Remove _channel_name

### DIFF
--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -3,8 +3,6 @@ require "active_support/test_case"
 
 class StimulusReflex::TestCase < ActiveSupport::TestCase
   class TestChannel < ActionCable::Channel::TestCase
-    _channel_class = StimulusReflex::Channel
-
     delegate :env, to: :connection
 
     def initialize(connection_opts = {})


### PR DESCRIPTION
As we're trying to upgrade from 3.0.0.pre1 to 3.4.0 we're running into an issue. The definition for `StimulusReflex::Channel` has been moved from the `lib` directory into `app/channel/stimulus_reflex`. If we require that file directly, we get an error that `ActionCable` is undefined. 

I originally added `_channel_class` as that's what the action-cable-testing library sets. I'm not convinced we need this variable declaration at _this time_. If this causes issues, or there is a better way proposed I'm _more_ than happy to revisit this.