### PR TITLE
Introduces morph expectation

### DIFF
--- a/lib/rspec/rails/matchers/stimulus_reflex.rb
+++ b/lib/rspec/rails/matchers/stimulus_reflex.rb
@@ -12,6 +12,10 @@ end
 
 RSpec::Matchers.define :morph do |selector|
   match do |morphs|
+    if morphs.is_a?(StimulusReflex::NothingBroadcaster)
+      return selector.to_s == "nothing"
+    end
+
     morph = matching_morph(morphs, selector)
 
     if morph.present? && @with_chain_called

--- a/lib/rspec/rails/matchers/stimulus_reflex.rb
+++ b/lib/rspec/rails/matchers/stimulus_reflex.rb
@@ -9,3 +9,46 @@ RSpec::Matchers.define :have_set do |instance_variable, expected_value|
     "set #{instance_variable} to #{expected_value}, got #{actual.get(instance_variable)}"
   end
 end
+
+RSpec::Matchers.define :morph do |selector|
+  match do |morphs|
+    morph = matching_morph(morphs, selector)
+
+    if morph.present? && @with_chain_called
+      @content == morph[1]
+    else
+      morph
+    end
+  end
+
+  description do |morphs|
+    morph = matching_morph(morphs, selector)
+
+    if @with_chain_called
+      if !morph
+        "morph #{selector} but a morph for that selector was not run"
+      else
+        "morph #{selector} with #{@content} but the value was: #{morph[1]}"
+      end
+    else
+      "morph #{selector} but a morph for that selector was not run"
+    end
+  end
+
+  chain :with do |content|
+    @with_chain_called = true
+    @content = content
+  end
+
+  def supports_block_expectations?
+    true
+  end
+
+  def matching_morph(morphs, selector)
+    if morphs.respond_to?(:call)
+      morphs.call.find { |morph| morph[0] == selector }
+    else
+      morphs.find { |morph| morph[0] == selector }
+    end
+  end
+end

--- a/lib/rspec/rails/matchers/stimulus_reflex.rb
+++ b/lib/rspec/rails/matchers/stimulus_reflex.rb
@@ -55,4 +55,6 @@ RSpec::Matchers.define :morph do |selector|
       morphs.find { |morph| morph[0] == selector }
     end
   end
+
+  diffable
 end


### PR DESCRIPTION
With the introduction of morph modes in SR (like how late am I?) I thought it would be nice to test that morphs function as we'd expect.

This PR introduces a `morph` mode with an optional `with` chain:

```ruby
expect(subject).to morph('#some_div')

expect(subject).to morph('#some_div').with('new content')

expect { subject }.to morph('#some_div').with('new content')

expect(subject).to morph(:nothing)
```