### PR TITLE
Broadcast matcher

### DIFF
--- a/lib/rspec/rails/matchers/stimulus_reflex.rb
+++ b/lib/rspec/rails/matchers/stimulus_reflex.rb
@@ -10,14 +10,24 @@ RSpec::Matchers.define :have_set do |instance_variable, expected_value|
   end
 end
 
-RSpec::Matchers.define :broadcast do |*broadcasts|
+RSpec::Matchers.define :broadcast do |**broadcasts|
   match do |block|
     fable_ready = StimulusReflex::TestReflexPatches::FableReady.new
 
-    allow_any_instance_of(StimulusReflex::CableReadyChannels).to receive(:[]).and_return(fable_ready)
+    allow_any_instance_of(StimulusReflex::CableReadyChannels).to(
+      receive(:[]).and_return(fable_ready)
+    )
 
     broadcasts.each do |broadcast|
-      expect(fable_ready).to receive(broadcast).and_return(fable_ready)
+      if broadcast.is_a?(Array)
+        if broadcast[1].present?
+          expect(fable_ready).to receive(broadcast[0]).with(broadcast[1]).and_return(fable_ready)
+        else
+          expect(fable_ready).to receive(broadcast[0]).and_return(fable_ready)
+        end
+      else
+        expect(fable_ready).to receive(broadcast).and_return(fable_ready)
+      end
     end
 
     block.call

--- a/lib/rspec/rails/matchers/stimulus_reflex.rb
+++ b/lib/rspec/rails/matchers/stimulus_reflex.rb
@@ -10,6 +10,26 @@ RSpec::Matchers.define :have_set do |instance_variable, expected_value|
   end
 end
 
+RSpec::Matchers.define :broadcast do |*broadcasts|
+  match do |block|
+    fable_ready = StimulusReflex::TestReflexPatches::FableReady.new
+
+    allow_any_instance_of(StimulusReflex::CableReadyChannels).to receive(:[]).and_return(fable_ready)
+
+    broadcasts.each do |broadcast|
+      expect(fable_ready).to receive(broadcast).and_return(fable_ready)
+    end
+
+    block.call
+
+    RSpec::Mocks.verify
+  end
+
+  def supports_block_expectations?
+    true
+  end
+end
+
 RSpec::Matchers.define :morph do |selector|
   match do |morphs|
     if morphs.is_a?(StimulusReflex::NothingBroadcaster)

--- a/lib/stimulus_reflex/test_reflex_patches.rb
+++ b/lib/stimulus_reflex/test_reflex_patches.rb
@@ -17,7 +17,7 @@ module StimulusReflex::TestReflexPatches
     end
 
     def method_missing(*)
-      true || super
+      self
     end
 
     def respond_to_missing?(*)


### PR DESCRIPTION
Introduces a VERY basic CR broadcast matcher to use inside a Reflex spec:

```ruby
# Testing just that the operations were called
expect { subject }.to broadcast(:remove, :insert_adjacent_html, :broadcast_to) 

# Testing that the operations were called with data
expect { subject }.to broadcast(
  remove: { selector: "#some_div" },
  insert_adjacent_html: { selector: "body", html: "<h1>Hi</h1>" },
  broadcast_to: user  
) 
```