### PR TITLE
Method name refactoring

### DIFF
--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -32,8 +32,14 @@ class StimulusReflex::TestCase < ActiveSupport::TestCase
       element = opts.fetch(:element, StimulusReflex::Element.new)
 
       self.class.reflex_class.new(
-        channel, element: element, url: opts.fetch(:url, ""), method_name: opts.dig(:method_name), params: opts.fetch(:params, {})
+        channel, element: element, url: opts.fetch(:url, ""), method_name: method_name_from_opts(opts), params: opts.fetch(:params, {})
       )
+    end
+
+    private
+
+    def method_name_from_opts(opts)
+      opts.dig(:method_name).to_s.presence
     end
   end
 

--- a/lib/stimulus_reflex/test_reflex_patches.rb
+++ b/lib/stimulus_reflex/test_reflex_patches.rb
@@ -3,8 +3,14 @@ module StimulusReflex::TestReflexPatches
     instance_variable_get("@#{instance_variable}")
   end
 
-  def run(method_name, *args)
-    process(method_name, *args)
+  def run(reflex_method = nil, *args)
+    reflex_to_run = reflex_method || method_name
+
+    if reflex_to_run
+      process(reflex_to_run, *args)
+    else
+      raise "You must provide the method you want to run for #{self.class.name}"
+    end
   end
 
   def cable_ready


### PR DESCRIPTION
When building a reflex in a spec, `method_name` has been an optional argument. We required `#run` to take a method name to run, though. This broke callbacks with an `:only` or `:except` modifier. If it was a callback that ran no matter what, the spec would run it correctly.

To fix this, I want to make the `method_name` in `build_reflex` the source of truth.

```ruby
# Before
build_reflex.run(:action)

# After
build_reflex(method_name: :action).run
```

For backward capability I've made it so you can pass an action to `#run` still, but will likely deprecate and remove that eventually.

Closes #13