### PR TITLE
Include StimulusReflex version number in the reflex data

### DIFF
--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -22,13 +22,20 @@ class StimulusReflex::TestCase < ActiveSupport::TestCase
   module Behavior
     extend ActiveSupport::Concern
 
-    def build_reflex(opts = {})
+    def build_reflex(opts = {}, stimulus_reflex_version = StimulusReflex::VERSION)
       channel = opts.fetch(:channel, TestChannel.new(opts.fetch(:connection, {})))
       element = opts.fetch(:element, StimulusReflex::Element.new)
+      version = stimulus_reflex_version
 
-      self.class.reflex_class.new(
-        channel, element: element, url: opts.fetch(:url, ""), method_name: method_name_from_opts(opts), params: opts.fetch(:params, {})
-      )
+      args_350_pre8 = { element: element, url: opts.fetch(:url, ""), method_name: method_name_from_opts(opts),
+                        params: opts.fetch(:params, {}), client_attributes: {} }
+      args_350_pre9 = { **args_350_pre8, client_attributes: { version: version } }
+
+      if Gem::Version.new(version) > Gem::Version.new('3.5.0pre8')
+        self.class.reflex_class.new(channel, args_350_pre9)
+      else
+        self.class.reflex_class.new(channel, args_350_pre8)
+      end
     end
 
     private

--- a/test/stimulus_reflex_testing_test.rb
+++ b/test/stimulus_reflex_testing_test.rb
@@ -5,7 +5,42 @@ class StimulusReflexTestingTest < Minitest::Test
     refute_nil ::StimulusReflexTesting::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_includes_version_number_for_sr_350pre9_and_newer
+    mock = MiniTest::Mock.new
+    opts = { channel: 'TestChannel', element: 'TestElement', url: 'https://test.xyz', method_name: 'test' }
+
+    mock.expect(:call, true) do |channel, element:, url:, method_name:, params:, client_attributes:|
+      assert_equal('3.5.0pre9', client_attributes[:version])
+    end
+
+    TestReflexClass.stub(:new, mock) do
+      TestClass.new.build_reflex(opts, '3.5.0pre9')
+    end
+    mock.verify
   end
+
+  def test_does_not_include_version_number_for_sr_350pre8_and_older
+    mock = MiniTest::Mock.new
+    opts = { channel: 'TestChannel', element: 'TestElement', url: 'https://test.xyz', method_name: 'test' }
+
+    mock.expect(:call, true) do |channel, element:, url:, method_name:, params:, client_attributes:|
+      assert_nil(client_attributes[:version])
+    end
+
+    TestReflexClass.stub(:new, mock) do
+      TestClass.new.build_reflex(opts, '3.5.0pre8')
+    end
+  end
+end
+
+class TestClass
+  include StimulusReflex::TestCase::Behavior
+
+  def self.reflex_class
+    TestReflexClass
+  end
+end
+
+class TestReflexClass
+  def initialize(channel, url:, element:, method_name:, params:, client_attributes:); true; end
 end


### PR DESCRIPTION
StimulusReflex 3.5.0pre9 verifies that the client and server are
running the same version by including it in the reflex data. This adds
the version number to the `build_reflex` method to match what the
actual library does.

https://github.com/stimulusreflex/stimulus_reflex/pull/561

Fixes #17