### PR TITLE
Convert opts to kwargs before instantiating reflex

### DIFF
--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -32,9 +32,9 @@ class StimulusReflex::TestCase < ActiveSupport::TestCase
       args_350_pre9 = { **args_350_pre8, client_attributes: { version: version } }
 
       if Gem::Version.new(version) > Gem::Version.new('3.5.0pre8')
-        self.class.reflex_class.new(channel, args_350_pre9)
+        self.class.reflex_class.new(channel, **args_350_pre9)
       else
-        self.class.reflex_class.new(channel, args_350_pre8)
+        self.class.reflex_class.new(channel, **args_350_pre8)
       end
     end
 

--- a/test/build_reflex_test.rb
+++ b/test/build_reflex_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class BuildReflexTest < MiniTest::Test
+  class TestReflex < StimulusReflex::Reflex
+  end
+
+  class TestClass
+    include StimulusReflex::TestCase::Behavior
+    def self.reflex_class
+      TestReflex
+    end
+  end
+
+  def test_it_supplies_the_correct_arguments_to_a_reflex
+    mock = MiniTest::Mock.new
+    mock.expect(:call, nil, [StimulusReflex::TestCase::TestChannel, Hash])
+
+    TestReflex.stub(:new, mock) do
+      TestClass.new.build_reflex(method_name: :create, url: 'http://localhost/url')
+    end
+
+    mock.verify
+  end
+end


### PR DESCRIPTION
Ruby 3 does not support automatically converting a hash argument into
keyword arguments. Using a double-splat to turn the hash into keyword
arguments before instantiating the reflex ensures that this will be
compatible with the currently supported ruby version for this gem and
later versions as well.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes #19