### PR TITLE
Use ReflexData that is now required for SR 3.5.0.rc4.

### DIFF
--- a/lib/stimulus_reflex/test_case.rb
+++ b/lib/stimulus_reflex/test_case.rb
@@ -31,7 +31,10 @@ class StimulusReflex::TestCase < ActiveSupport::TestCase
                         params: opts.fetch(:params, {}), client_attributes: {} }
       args_350_pre9 = { **args_350_pre8, client_attributes: { version: version } }
 
-      if Gem::Version.new(version) > Gem::Version.new('3.5.0pre8')
+      if Gem::Version.new(version) >= Gem::Version.new('3.5.0.rc4')
+        args_350_rc4 = { reflex_data: StimulusReflex::ReflexData.new({ **args_350_pre8, version: version }) }
+        self.class.reflex_class.new(channel, **args_350_rc4)
+      elsif Gem::Version.new(version) > Gem::Version.new('3.5.0pre8')
         self.class.reflex_class.new(channel, **args_350_pre9)
       else
         self.class.reflex_class.new(channel, **args_350_pre8)


### PR DESCRIPTION
Hi, how is it going?

I'm opening this PR to start a discussion on how we can merge this change to fix the issue we're facing our project. The change here works fine on our end (we pointed our dependency of this gem to my fork).

To make this PR good though, I would like to add some test, which I can't because the new class `StimulusReflex::ReflexData` is only available on a pre-release version. The new SR pre-release version is also on ruby 3.

Do you have any ideas on how we can proceed here? I'm not familiar on how gems handle these kind of situations... FWIW, the current change won't break older versions since that code with the new class won't be evaluated unless you're on the proper SR version.

Let me know if you have any thoughts. Happy to help in any way I can!

---------------------------------------------------------------------------------
Here's the description in the commit:

As seem on the Changelog:

https://github.com/stimulusreflex/stimulus_reflex/compare/v3.5.0.rc3...v3.5.0.rc4

More specifically, this commit:

https://github.com/stimulusreflex/stimulus_reflex/commit/3137a0f36a27dc26ee271eee5c17c3a96dce280d#diff-87b7a54fdec6e28f9dee9180a91acf18c74c073940340e9e6d56b5fcb9679c40R27

The commit changes how a Reflex is initialized. It only accepts 2 params now: channel and reflex_data.

This error was identified on a repo running StimulusReflex 3.5.0.rc4 with the stimulus_reflex_testing gem:

```
     Failure/Error:
       build_reflex(
         url:,
         params:,
         connection:
       )

     ArgumentError:
       missing keyword: :reflex_data
```